### PR TITLE
Update package references

### DIFF
--- a/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.Slipping.Web/Triad.CabinetOffice.Slipping.Web.csproj
+++ b/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.Slipping.Web/Triad.CabinetOffice.Slipping.Web.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Triad.CabinetOffice.Slipping.Web</RootNamespace>
     <AssemblyName>Triad.CabinetOffice.Slipping.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -54,26 +54,56 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="JWT, Version=1.3.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JWT.1.3.4\lib\3.5\JWT.dll</HintPath>
+    <Reference Include="GovukNotify, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GovukNotify.6.0.0\lib\net462\GovukNotify.dll</HintPath>
+    </Reference>
+    <Reference Include="JWT, Version=7.0.0.0, Culture=neutral, PublicKeyToken=6f98bca0f40f2ecf, processorArchitecture=MSIL">
+      <HintPath>..\packages\JWT.7.1.0\lib\net46\JWT.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Owin, Version=4.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.1.1\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Notify, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Notify.1.4.0\lib\net452\Notify.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Specialized, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Specialized.4.3.0\lib\net46\System.Collections.Specialized.dll</HintPath>
+    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -89,8 +119,6 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http">
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
@@ -135,9 +163,6 @@
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin">
-      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Owin.Host.SystemWeb">
       <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.3.0.1\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
@@ -155,9 +180,6 @@
     </Reference>
     <Reference Include="Microsoft.Owin.Security.OpenIdConnect">
       <HintPath>..\packages\Microsoft.Owin.Security.OpenIdConnect.3.0.1\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.0.6\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
@@ -313,7 +335,9 @@
     <Folder Include="App_Data\" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="packages.config" />
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Scripts\jquery-1.10.2.min.map" />

--- a/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.Slipping.Web/Web.config
+++ b/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.Slipping.Web/Web.config
@@ -4,8 +4,7 @@
   https://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
-  <appSettings configSource="hiddenAppSettings.config">
-  </appSettings>
+  <appSettings configSource="hiddenAppSettings.config" />
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
@@ -16,7 +15,7 @@
   -->
   <system.web>
     <globalization culture="en-GB" uiCulture="en-GB" />
-    <compilation debug="true" targetFramework="4.5.2" />
+    <compilation debug="true" targetFramework="4.6.2" />
     <httpRuntime targetFramework="4.5.2" enableVersionHeader="false" />
     <httpModules>
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
@@ -26,7 +25,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
@@ -47,6 +46,14 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -69,6 +76,5 @@
       <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
-  <connectionStrings configSource="hiddenConnectionStrings.config">
-  </connectionStrings>
+  <connectionStrings configSource="hiddenConnectionStrings.config" />
 </configuration>

--- a/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.Slipping.Web/packages.config
+++ b/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.Slipping.Web/packages.config
@@ -2,10 +2,11 @@
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
+  <package id="GovukNotify" version="6.0.0" targetFramework="net462" />
   <package id="jQuery" version="1.10.2" targetFramework="net452" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net452" />
-  <package id="JWT" version="1.3.4" targetFramework="net452" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net452" />
+  <package id="JWT" version="7.1.0" targetFramework="net462" />
+  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net462" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.6" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.2.0" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.2.0" targetFramework="net452" />
@@ -20,16 +21,23 @@
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.3" targetFramework="net452" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net452" developmentDependency="true" />
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin" version="4.1.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security.Cookies" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security.OpenIdConnect" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Modernizr" version="2.6.2" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="Notify" version="1.4.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="System.Collections.Specialized" version="4.3.0" targetFramework="net462" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
   <package id="WebGrease" version="1.5.2" targetFramework="net452" />
 </packages>

--- a/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.SlippingPublic.Web/Triad.CabinetOffice.SlippingPublic.Web.csproj
+++ b/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.SlippingPublic.Web/Triad.CabinetOffice.SlippingPublic.Web.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Triad.CabinetOffice.SlippingPublic.Web</RootNamespace>
     <AssemblyName>Triad.CabinetOffice.SlippingPublic.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -54,8 +54,14 @@
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="JWT, Version=1.3.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\JWT.1.3.4\lib\3.5\JWT.dll</HintPath>
+    <Reference Include="GovukNotify, Version=6.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GovukNotify.6.0.0\lib\net462\GovukNotify.dll</HintPath>
+    </Reference>
+    <Reference Include="JWT, Version=7.0.0.0, Culture=neutral, PublicKeyToken=6f98bca0f40f2ecf, processorArchitecture=MSIL">
+      <HintPath>..\packages\JWT.7.1.0\lib\net46\JWT.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
@@ -64,16 +70,37 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Notify, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Notify.1.4.0\lib\net452\Notify.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Specialized, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Specialized.4.3.0\lib\net46\System.Collections.Specialized.dll</HintPath>
+    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.4.3.0\lib\net462\System.Reflection.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Extensions, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.Extensions.4.3.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -89,8 +116,6 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http">
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
@@ -155,9 +180,6 @@
     </Reference>
     <Reference Include="Microsoft.Owin.Security.OpenIdConnect">
       <HintPath>..\packages\Microsoft.Owin.Security.OpenIdConnect.3.0.1\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.ApplicationInsights">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.2.2.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AI.Agent.Intercept">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.0.6\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>

--- a/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.SlippingPublic.Web/Web.config
+++ b/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.SlippingPublic.Web/Web.config
@@ -4,8 +4,7 @@
   https://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
-  <appSettings configSource="hiddenAppSettings.config">
-  </appSettings>
+  <appSettings configSource="hiddenAppSettings.config" />
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
@@ -16,7 +15,7 @@
   -->
   <system.web>
     <globalization culture="en-GB" uiCulture="en-GB" />
-    <compilation debug="true" targetFramework="4.5.2" />
+    <compilation debug="true" targetFramework="4.6.2" />
     <httpRuntime targetFramework="4.5.2" enableVersionHeader="false" />
     <httpModules>
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" />
@@ -47,6 +46,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.SlippingPublic.Web/packages.config
+++ b/Triad.CabinetOffice.Slipping/Triad.CabinetOffice.SlippingPublic.Web/packages.config
@@ -2,10 +2,11 @@
 <packages>
   <package id="Antlr" version="3.4.1.9004" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
+  <package id="GovukNotify" version="6.0.0" targetFramework="net462" />
   <package id="jQuery" version="1.10.2" targetFramework="net452" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net452" />
-  <package id="JWT" version="1.3.4" targetFramework="net452" />
-  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net452" />
+  <package id="JWT" version="7.1.0" targetFramework="net462" />
+  <package id="Microsoft.ApplicationInsights" version="2.2.0" targetFramework="net462" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.0.6" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.2.0" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.2.0" targetFramework="net452" />
@@ -28,8 +29,15 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Modernizr" version="2.6.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />
-  <package id="Notify" version="1.4.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="System.Collections.Specialized" version="4.3.0" targetFramework="net462" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
   <package id="WebGrease" version="1.5.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Further to the automated change made by dependabot - updated the references in slipping as well as slippingPublic
Also updated Notify reference, required retargeting to .net 4.6.2 (matches PAWS)
